### PR TITLE
Tidy up CSS and fix all lint errors in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,66 +1,216 @@
 <!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
-    <meta https-equiv=content-type charset="UTF-8">
+    <meta https-equiv="content-type" charset="UTF-8">
     <title>Monty Links</title>
-    <style type=text/css>
+    <style type="text/css">
         body {
-            border-top-width: 0px; font-weight: normal; border-left-width: 0px; font-size: 75%;  float: left; border-bottom-width: 0px; margin: 0px; font-family: verdana, arial, helvetica, sans-serif; border-right-width: 0px
+            border-top-width: 0px;
+            border-left-width: 0px;
+            border-bottom-width: 0px;
+            border-right-width: 0px
+            font-weight: normal;
+            font-size: 75%;
+            float: left;
+            margin: 0px;
+            font-family: verdana, arial, helvetica, sans-serif;
         }
-        #container {
+        
+        h1 {
+            font-weight: bold;
+            font-size: 18px;
+            color: #000;
+            padding-left:20px;
+            margin: 6px 0;
+        }
+        
+        h3 {
+            font-weight: bold;
+            font-size: 17px;
+            color: #666;
+            text-transform: capitalize;
+            margin-top: 3px;
+        }
+        
+        h3 span {
+            font-size:11px;
+        }
+        
+        h4 {
+            font-weight: bold;
+            font-size: 12px;
+            color: #000
+        }
+
+        a, a:visited, a:active {
+            text-decoration: none;
+            line-height: 12px;
+            background: silver;
+            padding: 3px;
+            border:1px solid black;
+            border-radius: 3px;
+            color: black;
+            margin-right: 3px;
+        }
+        
+        table a,
+        table a:visited  {
+            color:black;
+            background: transparent;
+            border: none;
+            text-transform: uppercase;
             margin: 0;
-            width: 100%;
         }
-        h1 {font-weight: bold; font-size: 18px; color: #000; padding-left: 20px; margin: 6px 0;}
-        h3 {font-weight: bold; font-size: 17px; color: #666; text-transform: capitalize; margin-top: 3px;}
-        h3 span {font-size:11px;}
-        h4 {font-weight: bold; font-size: 12px; color: #000}
+        
+        table a:hover,
+        table a:active {
+            color:white;
+            background: transparent !important;
+            border: none !important;
+        }
 
-        a, a:visited, a:active {text-decoration: none; line-height: 12px; background:silver; padding: 3px; border:1px solid black; border-radius: 3px; color: black; margin-right: 3px;}
-        table a,table a:visited  {color:black; background: transparent; border: none; text-transform:uppercase; margin: 0;}
-        table a:hover, table a:active {color:white;background: transparent !important; border: none !important;}
+        table {
+            width:100%;
+            border: 1px solid black;
+            border-radius: 4px;
+            margin-bottom: 3px;
+            padding:0;
+            background: silver;
+        }
+        
+        td {
+            border: none;
+            background: silver;
+            text-align: center;
+            background: white;
+        }
+        
+        .style5 {
+            font-weight: bold;
+        }
 
-        table { width:100%; border: 1px solid black; border-radius: 4px; margin-bottom: 3px; padding:0; background: silver;}
-        td {border:none; background: silver; text-align: center; background: white;}
-        .style5 {font-weight: bold;}
-
-        #Local_Container {border: 1px solid #6c9636; border-radius:6px; background: #c6f28c; padding: 5px; margin: 5px 10px; float:left;}
+        #Local_Container {
+            border: 1px solid #6c9636;
+            border-radius:6px;
+            background: #c6f28c;
+            padding: 5px;
+            margin: 5px 10px;
+            float: left;
+        }
+        
         #Local_Container .style5,
-        #Local_Container td:hover{background: #6c9636; color:white; }
-        #Local_Container a:hover {background: #6c9636; color:white; border:1px solid black;}
+        #Local_Container td:hover {
+            background: #6c9636;
+            color: white;
+        }
+        
+        #Local_Container a:hover {
+            background: #6c9636;
+            color: white;
+            border:1px solid black;
+        }
 
-        #Prod_Container {border: 1px solid orange;  border-radius: 6px; background:#FFEAAD; padding: 5px; margin: 5px 10px; float: left; }
+        #Prod_Container {
+            border: 1px solid orange;
+            border-radius: 6px;
+            background: #FFEAAD;
+            padding: 5px;
+            margin: 5px 10px;
+            float: left;
+        }
+        
         #Prod_Container .style5,
-        #Prod_Container td:hover{background: orange; color:#000; }
-        #Prod_Container a:hover {background: orange; color:white; border:1px solid brown;}
+        #Prod_Container td:hover{
+            background: orange;
+            color: #000;
+        }
+        
+        #Prod_Container a:hover {
+            background: orange;
+            color: white;
+            border: 1px solid brown;
+        }
 
-        #QA_Container {border: 1px solid #6875FF; border-radius: 6px; background:#DCD5FF;  padding: 5px; margin: 5px 10px; float:left;  }
+        #QA_Container {
+            border: 1px solid #6875FF;
+            border-radius: 6px;
+            background:#DCD5FF;
+            padding: 5px;
+            margin: 5px 10px;
+            float: left;
+        }
+        
         #QA_Container .style5,
-        #QA_Container td:hover{background: #6875FF; color:white; }
-        #QA_Container a:hover {background: #6875FF; color:white; border:1px solid black;}
+        #QA_Container td:hover {
+            background: #6875FF;
+            color: white;
+        }
+        
+        #QA_Container a:hover {
+            background: #6875FF;
+            color: white;
+            border: 1px solid black;
+        }
 
-        #Other_Container {border: 1px solid #9933cc;  border-radius:6px; background: #EFCDFF; padding: 5px; margin: 5px 10px; float: left;}
-        #Other_Container .style5,
-        #Other_Container td:hover{background: #9933cc; color:white; }
-        #Other_Container a:hover {background: #9933cc; color:white; border:1px solid black;}
+        #PreProd_Container {
+            border: 1px solid #9933cc;
+            border-radius: 6px;
+            background: #EFCDFF;
+            padding: 5px;
+            margin: 5px 10px;
+            float: left;
+        }
+        
+        #PreProd_Container .style5,
+        #PreProd_Container td:hover {
+            background: #9933cc;
+            color: white;
+        }
+        
+        #PreProd_Container a:hover {
+            background: #9933cc;
+            color:white;
+            border: 1px solid black;
+        }
 
-        #Integration_Container {border: 1px solid #27a1a5; border-radius:6px; background: #9eedef; padding: 5px; margin: 5px 10px; float:left;}
+        #Integration_Container {
+            border: 1px solid #27a1a5;
+            border-radius: 6px;
+            background: #9eedef;
+            padding: 5px;
+            margin: 5px 10px;
+            float: left;
+        }
+        
         #Integration_Container .style5,
-        #Integration_Container td:hover{background: #27a1a5; color:white; }
-        #Integration_Container a:hover {background: #27a1a5; color:white; border:1px solid black;}
+        #Integration_Container td:hover {
+            background: #27a1a5;
+            color: white;
+        }
+        
+        #Integration_Container a:hover {
+            background: #27a1a5;
+            color: white;
+            border: 1px solid black;
+        }
 
-        #Grid_Dimensions {margin-left: 10px; width: 310px; margin-right: 10px;}
+        .Grid_Dimensions {
+            margin-left: 10px;
+            width: 310px;
+            margin-right: 10px;
+        }
 
-        #Prod_Container, #QA_Container, #Other_Container, #Integration_Container, #Local_Container{
+        #Prod_Container,
+        #QA_Container,
+        #PreProd_Container,
+        #Integration_Container,
+        #Local_Container {
             -webkit-box-shadow: 3px 3px 9px rgba(192, 0, 0, 0.32);
             -moz-box-shadow:    3px 3px 9px rgba(192, 0, 0, 0.32);
             box-shadow:         3px 3px 9px rgba(192, 0, 0, 0.32);
         }
-
     </style>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
-    <script type="text/javascript">
-    </script>
     <script type="text/javascript">
       function navigateTo(sel, target, newWindow) {
         var url = sel.options[sel.selectedIndex].value;
@@ -73,427 +223,418 @@
     </script>
 </head>
 <body>
-<div id=container>
     <h1>Mobile Links</h1>
-    <div class=Local_Container id=Local_Container>
-        <div class=Grid_Dimensions id=Grid_Dimensions>
-            <h3 class=Heading2>Local<br><span class="style1"></span></h3>
+    <div class="Local_Container" id="Local_Container">
+        <div class="Grid_Dimensions">
+            <h3 class="Heading2">Local<br><span class="style1"></span></h3>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=11><div align=center>UK</div></td></tr>
+                    <td class="style5" colspan="11"><div align="center">UK</div></td>
+                </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="http://local.m.evans.co.uk:8080/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.missselfridge.com:8080/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.topman.com:8080/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.wallis.co.uk:8080/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.burton.co.uk:8080/?montydebug">br</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.dorothyperkins.com:8080/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.topshop.com:8080/?montydebug">ts</a></td>
-                <tr>
+                    <td class="staging_6" width="16"><a href="http://local.m.evans.co.uk:8080/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.missselfridge.com:8080/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.topman.com:8080/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.wallis.co.uk:8080/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.burton.co.uk:8080/?montydebug">br</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.dorothyperkins.com:8080/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.topshop.com:8080/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=7><div align=center>US</div></td>
+                    <td class="style5" colspan="7"><div align="center">US</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="http://local.m.evansusa.com:8080/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.us.missselfridge.com:8080/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.us.topman.com:8080/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.wallisfashion.com:8080/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.us.dorothyperkins.com:8080/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.us.topshop.com:8080/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.evansusa.com:8080/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.us.missselfridge.com:8080/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.us.topman.com:8080/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.wallisfashion.com:8080/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.us.dorothyperkins.com:8080/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.us.topshop.com:8080/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colSpan=7><div align=center>FRANCE </div></td>
+                    <td class="style5" colspan="7"><div align="center">FRANCE</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="http://local.m.missselfridge.fr:8080/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.fr.topman.com:8080/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.fr.topshop.com:8080/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.missselfridge.fr:8080/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.fr.topman.com:8080/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.fr.topshop.com:8080/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            </table>
-            <table width=287 border=1 padding="7">
+            <table width="287" border="1" padding="7">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=7><div align=center>GERMANY</div></td>
+                    <td class="style5" colspan="7"><div align="center">GERMANY</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="http://local.m.evansmode.de:8080/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.missselfridge.de:8080/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.de.topman.com:8080/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.wallismode.de:8080/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.de.topshop.com:8080/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.evansmode.de:8080/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.missselfridge.de:8080/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.de.topman.com:8080/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.wallismode.de:8080/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.de.topshop.com:8080/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=8><div align=center>EU</div></td>
+                    <td class="style5" colspan="8"><div align="center">EU</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="http://local.m.euro.evansfashion.com:8080/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.euro.missselfridge.com:8080/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.eu.topman.com:8080/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.euro.wallisfashion.com:8080/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.eu.burton-menswear.com:8080/?montydebug">br</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.euro.dorothyperkins.com:8080/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="http://local.m.eu.topshop.com:8080/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.euro.evansfashion.com:8080/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.euro.missselfridge.com:8080/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.eu.topman.com:8080/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.euro.wallisfashion.com:8080/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.eu.burton-menswear.com:8080/?montydebug">br</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.euro.dorothyperkins.com:8080/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="http://local.m.eu.topshop.com:8080/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
-
         </div>
     </div>
-    <div class=Integration_Container id=Integration_Container>
-        <div class=Grid_Dimensions id="Grid_Dimensions">
-            <h3 class=Heading2>Integration <span class="style1"><br></span> </h3>
+    <div class="Integration_Container" id="Integration_Container">
+        <div class="Grid_Dimensions">
+            <h3 class="Heading2">Integration <span class="style1"><br></span> </h3>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=11><div align=center>UK</div></td></tr>
+                    <td class="style5" colspan="11"><div align="center">UK</div></td></tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://integration.m.evans.co.uk/?montydebug">EV</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.missselfridge.com/?montydebug">MS</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.wallis.co.uk/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.burton.co.uk/?montydebug">br</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.dorothyperkins.com/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.evans.co.uk/?montydebug">EV</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.missselfridge.com/?montydebug">MS</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.wallis.co.uk/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.burton.co.uk/?montydebug">br</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.dorothyperkins.com/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=7><div align=center>US</div></td>
+                    <td class="style5" colspan="7"><div align="center">US</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://integration.m.evansusa.com/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.us.missselfridge.com/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.us.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.wallisfashion.com/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.us.dorothyperkins.com/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.us.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.evansusa.com/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.us.missselfridge.com/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.us.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.wallisfashion.com/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.us.dorothyperkins.com/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.us.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colSpan=7><div align=center>FRANCE</div></td>
+                    <td class="style5" colspan="7"><div align="center">FRANCE</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://integration.m.missselfridge.fr/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.fr.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.fr.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.missselfridge.fr/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.fr.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.fr.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            </table>
-            <table width=287 border=1 padding="7">
+            <table width="287" border="1" padding="7">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=7><div align=center>GERMANY</div></td>
+                    <td class="style5" colspan="7"><div align="center">GERMANY</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://integration.m.evansmode.de/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.missselfridge.de/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.de.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.wallismode.de/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.de.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.evansmode.de/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.missselfridge.de/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.de.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.wallismode.de/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.de.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=8><div align=center>EU</div></td>
+                    <td class="style5" colspan="8"><div align="center">EU</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://integration.m.euro.evansfashion.com/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.euro.missselfridge.com/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.eu.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.euro.wallisfashion.com/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.eu.burton-menswear.com/?montydebug">br</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.euro.dorothyperkins.com/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="https://integration.m.eu.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.euro.evansfashion.com/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.euro.missselfridge.com/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.eu.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.euro.wallisfashion.com/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.eu.burton-menswear.com/?montydebug">br</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.euro.dorothyperkins.com/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="https://integration.m.eu.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
-
         </div>
     </div>
-    <div class=QA_Container id=QA_Container>
-        <div class=Grid_Dimensions id=Grid_Dimensions>
-            <h3 class=Heading2>Showcase<br><span class="style1"></span></h3>
+    <div class="QA_Container" id="QA_Container">
+        <div class="Grid_Dimensions">
+            <h3 class="Heading2">Showcase<br><span class="style1"></span></h3>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=11><div align=center>UK</div></td></tr>
+                    <td class="style5" colspan="11"><div align="center">UK</div></td>
+                </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://showcase.m.evans.co.uk/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.missselfridge.com/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.wallis.co.uk/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.burton.co.uk/?montydebug">br</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.dorothyperkins.com/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.topshop.com/?montydebug">ts</a></td>
-                <tr>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.evans.co.uk/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.missselfridge.com/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.wallis.co.uk/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.burton.co.uk/?montydebug">br</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.dorothyperkins.com/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=7><div align=center>US</div></td>
+                    <td class="style5" colspan="7"><div align="center">US</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://showcase.m.evansusa.com/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.us.missselfridge.com/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.us.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.wallisfashion.com/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.us.dorothyperkins.com/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.us.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.evansusa.com/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.us.missselfridge.com/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.us.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.wallisfashion.com/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.us.dorothyperkins.com/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.us.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colSpan=7><div align=center>FRANCE </div></td>
+                    <td class="style5" colspan="7"><div align="center">FRANCE</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://showcase.m.missselfridge.fr/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.fr.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.fr.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.missselfridge.fr/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.fr.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.fr.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            </table>
-            <table width=287 border=1 padding="7">
+            <table width="287" border="1" padding="7">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=7><div align=center>GERMANY</div></td>
+                    <td class="style5" colspan="7"><div align="center">GERMANY</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://showcase.m.evansmode.de/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.missselfridge.de/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.de.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.wallismode.de/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.de.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.evansmode.de/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.missselfridge.de/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.de.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.wallismode.de/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.de.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=8><div align=center>EU</div></td>
+                    <td class="style5" colspan="8"><div align="center">EU</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://showcase.m.euro.evansfashion.com/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.euro.missselfridge.com/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.eu.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.euro.wallisfashion.com/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.eu.burton-menswear.com/?montydebug">br</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.euro.dorothyperkins.com/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="https://showcase.m.eu.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.euro.evansfashion.com/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.euro.missselfridge.com/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.eu.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.euro.wallisfashion.com/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.eu.burton-menswear.com/?montydebug">br</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.euro.dorothyperkins.com/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="https://showcase.m.eu.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
-
         </div>
     </div>
 
-    <div class=Other_Container id="Other_Container">
-        <div class=Grid_Dimensions id="Grid_Dimensions">
+    <div class="PreProd_Container" id="PreProd_Container">
+        <div class="Grid_Dimensions">
             <h3>Preprod<span class="style1"><br></span></h3>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=11><div align=center>UK</div></td></tr>
+                    <td class="style5" colspan="11"><div align="center">UK</div></td>
+                </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://preprod.m.evans.co.uk/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.missselfridge.com/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.wallis.co.uk/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.burton.co.uk/?montydebug">br</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.dorothyperkins.com/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.topshop.com/?montydebug">ts</a></td>
-                <tr>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.evans.co.uk/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.missselfridge.com/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.wallis.co.uk/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.burton.co.uk/?montydebug">br</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.dorothyperkins.com/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=7><div align=center>US</div></td>
+                    <td class="style5" colspan="7"><div align="center">US</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://preprod.m.evansusa.com/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.us.missselfridge.com/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.us.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.wallisfashion.com/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.us.dorothyperkins.com/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.us.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.evansusa.com/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.us.missselfridge.com/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.us.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.wallisfashion.com/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.us.dorothyperkins.com/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.us.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=7><div align=center>FRANCE</div></td>
+                    <td class="style5" colspan="7"><div align="center">FRANCE</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://preprod.m.missselfridge.fr/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.fr.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.fr.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.missselfridge.fr/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.fr.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.fr.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            </table>
-            <table width=287 border=1 padding="7">
+            <table width="287" border="1" padding="7">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=7><div align=center>GERMANY</div></td>
+                    <td class="style5" colspan="7"><div align="center">GERMANY</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://preprod.m.evansmode.de/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.missselfridge.de/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.de.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.wallismode.de/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://preprod.m.de.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.evansmode.de/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.missselfridge.de/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.de.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.wallismode.de/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.de.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=8><div align=center>EU</div></td>
+                    <td class="style5" colspan="8"><div align="center">EU</div></td>
                 </tr>
                 <tr>
-                    <TD class=staging_6 width=16><A href="https://preprod.m.euro.evansfashion.com/?montydebug">EV</A></TD>
-                    <TD class=staging_6 width=16><A href="https://preprod.m.euro.missselfridge.com/?montydebug">MS</A></TD>
-                    <TD class=staging_6 width=16><A href="https://preprod.m.eu.topman.com/?montydebug">TM</A></TD>
-                    <TD class=staging_6 width=16><A href="https://preprod.m.euro.wallisfashion.com/?montydebug">WL</A></TD>
-                    <TD class=staging_6 width=16><A href="https://preprod.m.eu.burton-menswear.com/?montydebug">BR</A></TD>
-                    <TD class=staging_6 width=16><A href="https://preprod.m.euro.dorothyperkins.com/?montydebug">DP</A></TD>
-                    <TD class=staging_6 width=16><A href="https://preprod.m.eu.topshop.com/?montydebug">TS</A></TD>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.euro.evansfashion.com/?montydebug">EV</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.euro.missselfridge.com/?montydebug">MS</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.eu.topman.com/?montydebug">TM</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.euro.wallisfashion.com/?montydebug">WL</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.eu.burton-menswear.com/?montydebug">BR</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.euro.dorothyperkins.com/?montydebug">DP</a></td>
+                    <td class="staging_6" width="16"><a href="https://preprod.m.eu.topshop.com/?montydebug">TS</a></td>
                 </tr>
                 </tbody>
             </table>
 
         </div>
     </div>
-    <div class=Prod_Container id="Prod_Container">
-        <div class=Grid_Dimensions id="Grid_Dimensions">
+    <div class="Prod_Container" id="Prod_Container">
+        <div class="Grid_Dimensions">
             <h3>Production<span class="style1"><br></span></h3>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=11><div align=center>UK</div></td></tr>
+                    <td class="style5" colspan="11"><div align="center">UK</div></td>
+                </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://m.evans.co.uk/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://m.missselfridge.com/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://m.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://m.wallis.co.uk/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://m.burton.co.uk/?montydebug">br</a></td>
-                    <td class=staging_6 width=16><a href="https://m.dorothyperkins.com/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="https://m.topshop.com/?montydebug">ts</a></td>
-                <tr>
+                    <td class="staging_6" width="16"><a href="https://m.evans.co.uk/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.missselfridge.com/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.wallis.co.uk/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.burton.co.uk/?montydebug">br</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.dorothyperkins.com/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=7><div align=center>US</div></td>
+                    <td class="style5" colspan="7"><div align="center">US</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://m.evansusa.com/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://m.us.missselfridge.com/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://m.us.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://m.wallisfashion.com/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://m.us.dorothyperkins.com/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="https://m.us.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.evansusa.com/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.us.missselfridge.com/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.us.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.wallisfashion.com/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.us.dorothyperkins.com/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.us.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=7><div align=center>FRANCE</div></td>
+                    <td class="style5" colspan="7"><div align="center">FRANCE</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://m.missselfridge.fr/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://m.fr.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://m.fr.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.missselfridge.fr/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.fr.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.fr.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            </table>
-            <table width=287 border=1 padding="7">
+            <table width="287" border="1" padding="7">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=7><div align=center>GERMANY</div></td>
+                    <td class="style5" colspan="7"><div align="center">GERMANY</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://m.evansmode.de/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://m.missselfridge.de/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://m.de.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://m.wallismode.de/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://m.de.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.evansmode.de/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.missselfridge.de/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.de.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.wallismode.de/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.de.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>
 
-            <table width=287 border=1 padding="11">
+            <table width="287" border="1" padding="11">
                 <tbody>
                 <tr>
-                    <td class=style5 colspan=8><div align=center>EU</div></td>
+                    <td class="style5" colspan="8"><div align="center">EU</div></td>
                 </tr>
                 <tr>
-                    <td class=staging_6 width=16><a href="https://m.euro.evansfashion.com/?montydebug">ev</a></td>
-                    <td class=staging_6 width=16><a href="https://m.euro.missselfridge.com/?montydebug">ms</a></td>
-                    <td class=staging_6 width=16><a href="https://m.eu.topman.com/?montydebug">tm</a></td>
-                    <td class=staging_6 width=16><a href="https://m.euro.wallisfashion.com/?montydebug">wl</a></td>
-                    <td class=staging_6 width=16><a href="https://m.eu.burton-menswear.com/?montydebug">br</a></td>
-                    <td class=staging_6 width=16><a href="https://m.euro.dorothyperkins.com/?montydebug">dp</a></td>
-                    <td class=staging_6 width=16><a href="https://m.eu.topshop.com/?montydebug">ts</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.euro.evansfashion.com/?montydebug">ev</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.euro.missselfridge.com/?montydebug">ms</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.eu.topman.com/?montydebug">tm</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.euro.wallisfashion.com/?montydebug">wl</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.eu.burton-menswear.com/?montydebug">br</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.euro.dorothyperkins.com/?montydebug">dp</a></td>
+                    <td class="staging_6" width="16"><a href="https://m.eu.topshop.com/?montydebug">ts</a></td>
                 </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
- Tidied up CSS formatting and id/class usage
- Removed unclosed / dangling HTML elements
 - Quoted element attributes

All these changes ended up fixing the layout flow problem that was pushing one of the environments to the right and leaving a gap to its left when shrinking the page.